### PR TITLE
Parse Thrift configuration inside Envoy plugin on init

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@
 .vscode
 
 # Python
-__pycache__
+__pycache__.idea/
+.idea/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1123,7 +1123,9 @@ dependencies = [
  "base64",
  "jwt-simple",
  "log",
+ "once_cell",
  "proxy-wasm",
+ "regex",
  "serde",
  "serde_json",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,8 @@ log = "0.4.26"
 proxy-wasm = "0.2.2"
 serde = "1.0.219"
 serde_json = "1.0.140"
+regex = "1.11.1"
+once_cell = "1.21.1"
 
 [profile.release]
 lto = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,7 +154,6 @@ impl Context for RootHandler {
         body_size: usize,
         _num_trailers: usize,
     ) {
-        log::info!("on_http_call_response (root)");
         // Gather the response body of previously dispatched async HTTP call.
         let body = match self.get_http_call_response_body(0, body_size) {
             Some(body) => body,
@@ -211,7 +210,6 @@ struct HttpHandler {
 
 impl HttpContext for HttpHandler {
     fn on_http_request_headers(&mut self, _num_headers: usize, _end_of_stream: bool) -> Action {
-        log::info!("on_http_request_headers");
         match self.authenticate() {
             Ok(claims) => self.token_claims = Some(claims),
             Err(e) => {
@@ -228,69 +226,15 @@ impl HttpContext for HttpHandler {
         Action::Continue
     }
 
-    // fn on_http_request_body(&mut self, _body_size: usize, end_of_stream: bool) -> Action {
-    //     // pause if we've already dispatched a call
-    //     if self.get_scopes_dispatched {
-    //         return Action::Pause;
-    //     }
-    //     if let Some(method_name) = self.get_thrift_method_from_body() {
-    //         self.apply_thrift_auth(method_name);
-    //         return Action::Pause;
-    //     }
-    // 
-    //     if end_of_stream {
-    //         log::info!("Reached end of stream without method name");
-    // 
-    //         self.send_http_response(
-    //             401,
-    //             vec![("Powered-By", POWERED_BY)],
-    //             Some(b"Access forbidden.\n"),
-    //         );
-    //     };
-    // 
-    //     Action::Pause
-    // }
-
-    // NOTE: I just wanted to send a fake http_response so we could trigger a "response handler"
-    // to come into the lifecycle. Unfortunately, the handler never got triggered. Something in self.send_http_response
-    // isn't working like I'd expect.
-
     fn on_http_request_body(&mut self, _body_size: usize, end_of_stream: bool) -> Action {
-        log::info!("on_http_request_body");
         // pause if we've already dispatched a call
         if self.get_scopes_dispatched {
             return Action::Pause;
         }
         if let Some(method_name) = self.get_thrift_method_from_body() {
-            log::info!("Thrift method: {:?}", method_name);
             self.get_scopes_dispatched = true;
-            match self.handle_get_scopes_locally(method_name) {
-                Ok(_) =>  return Action::Continue,
-                Err(AuthError::Unauthenticated(_)) => {
-                    self.send_http_response(
-                        401,
-                        vec![("Powered-By", POWERED_BY)],
-                        Some(b"Access forbidden.\n"),
-                    );
-                    
-                },
-                Err(AuthError::Unauthorized(_)) => {
-                    self.send_http_response(
-                        403,
-                        vec![("Powered-By", POWERED_BY)],
-                        Some(b"Unauthorized.\n"),
-                    );
-                }
-            }
-            // if self.apply_thrift_auth_locally(method_name).is_ok() {
-            //     return Action::Continue;
-            // } else {
-            //     self.send_http_response(
-            //         401,
-            //         vec![("Powered-By", POWERED_BY)],
-            //         Some(b"Access forbidden.\n"),
-            //     );
-            
+            self.handle_get_scopes_locally(method_name);
+            return Action::Continue;
         }
         if end_of_stream {
             log::info!("Reached end of stream without method name");
@@ -306,51 +250,9 @@ impl HttpContext for HttpHandler {
     }
 }
 
-impl Context for HttpHandler {
-    // fn on_http_call_response(
-    //     &mut self,
-    //     _token_id: u32,
-    //     _num_headers: usize,
-    //     body_size: usize,
-    //     _num_trailers: usize,
-    // ) {
-    //     let body = self.get_http_call_response_body(0, body_size);
-    //     self.handle_get_scopes_res(body);
-    // }
-
-    // This variant uses a locally parsed Thrift file
-    // fn on_http_call_response(
-    //     &mut self,
-    //     _token_id: u32,
-    //     _num_headers: usize,
-    //     body_size: usize,
-    //     _num_trailers: usize,
-    // ) {
-    //     log::info!("on_http_call_response");
-    //     let method_name = self
-    //         .get_http_call_response_header(THRIFT_METHOD_HEADER)
-    //         .map(|header| header)
-    //         .expect("Missing thrift method");
-    // 
-    //     self.handle_get_scopes_locally(method_name);
-    // }
-}
+impl Context for HttpHandler {}
 
 impl HttpHandler {
-    // fn apply_thrift_auth(&mut self, method_name: String) -> () {
-    //     match self.dispatch_get_scopes(method_name) {
-    //         Ok(_) => (),
-    //         Err(e) => {
-    //             log::warn!("failed to get scopes: {:?}", e);
-    // 
-    //             self.send_http_response(
-    //                 401,
-    //                 vec![("Powered-By", POWERED_BY)],
-    //                 Some(b"Access forbidden.\n"),
-    //             );
-    //         }
-    //     }
-    // }
 
     fn apply_thrift_auth_locally(&mut self, method_name: String) -> Result<(), Box<dyn Error>> {
         let service_name = self
@@ -388,43 +290,30 @@ impl HttpHandler {
         Some(method_name)
     }
 
-    fn handle_get_scopes_locally(&self, method_name: String) -> Result<Action, AuthError> {
+    fn handle_get_scopes_locally(&self, method_name: String){
         match self.validate_auth_with_local_thrift(method_name) {
-            Ok(_) => Ok(Action::Continue),
+            Ok(_) => self.resume_http_request(),
             Err(AuthError::Unauthenticated(message)) => {
                 log::warn!("Unauthenticated: {:?}", message);
-                Err(AuthError::Unauthenticated(message))
+
+                self.send_http_response(
+                    401,
+                    vec![("Powered-By", POWERED_BY)],
+                    Some(b"Access forbidden.\n"),
+                );
             }
             Err(AuthError::Unauthorized(message)) => {
                 log::warn!("Unauthorized: {:?}", message);
-                Err(AuthError::Unauthorized(message))
+
+                self.send_http_response(
+                    403,
+                    vec![("Powered-By", POWERED_BY)],
+                    Some(b"Access forbidden.\n"),
+                );
             }
         }
     }
-    fn validate_auth(&self, body: Option<Vec<u8>>) -> Result<(), AuthError> {
-        let claims = self
-            .token_claims
-            .as_ref()
-            .ok_or(AuthError::Unauthenticated(
-                "Missing token claims".to_string(),
-            ))?;
-
-        let parsed_scope_response = self
-            .parse_required_scopes(body)
-            .map_err(|e| AuthError::Unauthenticated(e.to_string()))?;
-
-        let required_scopes = parsed_scope_response
-            .scopes
-            .split_whitespace()
-            .map(String::from)
-            .collect::<Vec<String>>();
-
-        self.authorize(required_scopes, &claims.custom.scopes)
-            .map_err(|e| AuthError::Unauthorized(e.to_string()))?;
-
-        Ok(())
-    }
-
+    
     fn validate_auth_with_local_thrift(&self, method_name: String) -> Result<(), AuthError> {
         let claims = self
             .token_claims
@@ -459,15 +348,6 @@ impl HttpHandler {
             }).expect("TODO: panic message");
 
         Ok(())
-    }
-
-    fn parse_required_scopes(
-        &self,
-        body: Option<Vec<u8>>,
-    ) -> Result<GetScopesResponse, Box<dyn Error>> {
-        let body = body.ok_or("Empty body from scopes response")?;
-        let response: GetScopesResponse = from_slice(&body)?;
-        Ok(response)
     }
 
     fn authorize(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 mod parse;
 
+use std::collections::HashMap;
 use jwt_simple::{
     claims::JWTClaims,
     prelude::{RS256PublicKey, RSAPublicKeyLike},
@@ -15,10 +16,13 @@ use proxy_wasm::{
     traits::{Context, HttpContext, RootContext},
     types::{Action, ContextType, LogLevel},
 };
+use crate::parse::Service;
 
 const PUBLIC_KEY_REFRESH_INTERVAL: Duration = Duration::from_secs(3);
 const PUBLIC_KEY_CACHE_KEY: &str = "public_key";
 const POWERED_BY: &str = "wasm-envoy-proxy";
+
+const THRIFT_METHOD_HEADER: &str = "X-Thrift-Method";
 
 #[derive(Deserialize, Debug, Default, Clone)]
 #[serde(default)]
@@ -83,6 +87,7 @@ impl RootContext for RootHandler {
             token_claims: None,
             get_scopes_dispatched: false,
             scopes_file: include_str!("../hack/PotatoService.thrift").to_string(),
+            thrift_config: parse::parse_thrift(include_str!("../hack/PotatoService.thrift")).expect("failed to parse thrift file"),
         }))
     }
 
@@ -150,9 +155,14 @@ impl Context for RootHandler {
         body_size: usize,
         _num_trailers: usize,
     ) {
+        log::warn!("RAWR");
         // Gather the response body of previously dispatched async HTTP call.
         let body = match self.get_http_call_response_body(0, body_size) {
-            Some(body) => body,
+            Some(body) => {
+
+                log::warn!("RAWR body: {:?}", String::from_utf8_lossy(&body));
+                body
+            },
             None => {
                 log::warn!("header providing service returned empty body");
 
@@ -172,6 +182,7 @@ impl RootHandler {
                 log::error!("Failed to parse JWKS: {:?}", e);
                 return;
             }
+            
         };
 
         let pubkey_comps = match jwks.keys.iter().find(|key| key.alg == "RS256") {
@@ -202,10 +213,12 @@ struct HttpHandler {
     token_claims: Option<JWTClaims<CustomClaims>>,
     get_scopes_dispatched: bool,
     scopes_file: String,
+    thrift_config: HashMap<String, Service> 
 }
 
 impl HttpContext for HttpHandler {
     fn on_http_request_headers(&mut self, _num_headers: usize, _end_of_stream: bool) -> Action {
+        log::info!("on_http_request_headers");
         match self.authenticate() {
             Ok(claims) => self.token_claims = Some(claims),
             Err(e) => {
@@ -234,16 +247,47 @@ impl HttpContext for HttpHandler {
         
         if end_of_stream {
             log::info!("Reached end of stream without method name");
-
+    
             self.send_http_response(
                 401,
                 vec![("Powered-By", POWERED_BY)],
                 Some(b"Access forbidden.\n"),
             );
         };
-
+    
         Action::Pause
     }
+    
+    // fn on_http_request_body(&mut self, _body_size: usize, end_of_stream: bool) -> Action {
+    //     log::info!("on_http_request_body");
+    //     // pause if we've already dispatched a call
+    //     if self.get_scopes_dispatched {
+    //         return Action::Pause;
+    //     }
+    //     if let Some(method_name) = self.get_thrift_method_from_body() {
+    //         log::warn!("Thrift method: {:?}", method_name);
+    //         self.send_http_response(
+    //             200,
+    //             vec![("Powered-By", POWERED_BY), (THRIFT_METHOD_HEADER, method_name.as_str())],
+    //             None,
+    //         );
+    //         log::warn!("THRIFT_METHOD_HEADER returned");
+    //         self.get_scopes_dispatched = true;
+    //         return Action::Pause;
+    //     }
+    // 
+    //     if end_of_stream {
+    //         log::info!("Reached end of stream without method name");
+    // 
+    //         self.send_http_response(
+    //             401,
+    //             vec![("Powered-By", POWERED_BY)],
+    //             Some(b"Access forbidden.\n"),
+    //         );
+    //     };
+    // 
+    //     Action::Pause
+    // }
 }
 
 impl Context for HttpHandler {
@@ -257,6 +301,23 @@ impl Context for HttpHandler {
         let body = self.get_http_call_response_body(0, body_size);
         self.handle_get_scopes_res(body);
     }
+    
+    // // This variant uses a locally parsed Thrift file
+    // fn on_http_call_response(
+    //     &mut self,
+    //     _token_id: u32,
+    //     _num_headers: usize,
+    //     body_size: usize,
+    //     _num_trailers: usize,
+    // ) {
+    //     let _ = self.get_http_call_response_body(0, body_size);
+    //     let method_name = self
+    //         .get_http_call_response_header(THRIFT_METHOD_HEADER)
+    //         .map(|header| header)
+    //         .expect("Missing thrift method");
+    //     
+    //     self.handle_get_scopes_locally(method_name);
+    // }
 }
 
 impl HttpHandler {
@@ -273,7 +334,23 @@ impl HttpHandler {
                 );
             }
         }
+    }
+    
+    fn apply_thrift_auth_locally(&mut self, method_name: String) -> Result<(), Box<dyn Error>> {
+        let service_name = self
+            .config
+            .service_name
+            .as_ref()
+            .ok_or("Service name not found")?;
 
+        let required_scopes = self.thrift_config
+            .get(service_name)
+            .map(|service_thrift| service_thrift.methods.get(method_name.as_str()))
+            .map(|method| method.unwrap().annotations.clone())
+            .ok_or("Scopes not found")?;
+
+        println!("Scopes from Rust-parsed Thrift file: {:?}", required_scopes);
+        Ok(())
     }
 
     fn get_thrift_method_from_body(&self) -> Option<String> {
@@ -297,15 +374,6 @@ impl HttpHandler {
             .as_ref()
             .ok_or("Service name not found")?;
 
-        let service = parse::parse_thrift(self.scopes_file.as_str());
-        let required_scopes = service?
-            .get(service_name)
-            .map(|service_thrift| service_thrift.methods.get(method_name.as_str()))
-            .map(|method| method.unwrap().annotations.clone())
-            .ok_or("Scopes not found")?;
-        
-        println!("Scopes from Rust-parsed Thrift file: {:?}", required_scopes);
-        
         self.dispatch_http_call(
             "auth",
             vec![
@@ -349,6 +417,30 @@ impl HttpHandler {
         }
     }
 
+
+    // fn handle_get_scopes_locally(&self, method_name: String) {
+    //     match self.validate_auth_with_local_thrift(method_name) {
+    //         Ok(_) => self.resume_http_request(),
+    //         Err(AuthError::Unauthenticated(message)) => {
+    //             log::warn!("Unauthenticated: {:?}", message);
+    // 
+    //             self.send_http_response(
+    //                 401,
+    //                 vec![("Powered-By", POWERED_BY)],
+    //                 Some(b"Access forbidden.\n"),
+    //             );
+    //         }
+    //         Err(AuthError::Unauthorized(message)) => {
+    //             log::warn!("Unauthorized: {:?}", message);
+    // 
+    //             self.send_http_response(
+    //                 403,
+    //                 vec![("Powered-By", POWERED_BY)],
+    //                 Some(b"Access forbidden.\n"),
+    //             );
+    //         }
+    //     }
+    // }
     fn validate_auth(&self, body: Option<Vec<u8>>) -> Result<(), AuthError> {
         let claims = self
             .token_claims
@@ -366,6 +458,32 @@ impl HttpHandler {
             .collect::<Vec<String>>();
 
         self.authorize(required_scopes, &claims.custom.scopes)
+            .map_err(|e| AuthError::Unauthorized(e.to_string()))?;
+
+        Ok(())
+    }
+    
+    fn validate_auth_with_local_thrift(&self, method_name: String) -> Result<(), AuthError> {
+        let claims = self
+            .token_claims
+            .as_ref()
+            .ok_or(AuthError::Unauthenticated("Missing token claims".to_string()))?;
+
+        let service_name = self
+            .config
+            .service_name
+            .as_ref()
+            .expect("Service name not found");
+
+        let required_scopes = self.thrift_config
+            .get(service_name)
+            .map(|service_thrift| service_thrift.methods.get(method_name.as_str()))
+            .map(|method| method.unwrap().annotations.clone())
+            .ok_or("Scopes not found").expect("scopes not found by service_name and method");
+        
+        let required_scopes = vec![required_scopes.get("scope").expect("missing scopes")];
+        
+        self.authorize(required_scopes.iter().map(|s| s.to_string()).collect(), &claims.custom.scopes)
             .map_err(|e| AuthError::Unauthorized(e.to_string()))?;
 
         Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+mod parse;
+
 use jwt_simple::{
     claims::JWTClaims,
     prelude::{RS256PublicKey, RSAPublicKeyLike},
@@ -80,6 +82,7 @@ impl RootContext for RootHandler {
             config: self.config.clone(),
             token_claims: None,
             get_scopes_dispatched: false,
+            scopes_file: include_str!("../hack/PotatoService.thrift").to_string(),
         }))
     }
 
@@ -198,6 +201,7 @@ struct HttpHandler {
     config: FilterConfig,
     token_claims: Option<JWTClaims<CustomClaims>>,
     get_scopes_dispatched: bool,
+    scopes_file: String,
 }
 
 impl HttpContext for HttpHandler {
@@ -293,6 +297,15 @@ impl HttpHandler {
             .as_ref()
             .ok_or("Service name not found")?;
 
+        let service = parse::parse_thrift(self.scopes_file.as_str());
+        let required_scopes = service?
+            .get(service_name)
+            .map(|service_thrift| service_thrift.methods.get(method_name.as_str()))
+            .map(|method| method.unwrap().annotations.clone())
+            .ok_or("Scopes not found")?;
+        
+        println!("Scopes from Rust-parsed Thrift file: {:?}", required_scopes);
+        
         self.dispatch_http_call(
             "auth",
             vec![

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,6 +154,7 @@ impl Context for RootHandler {
         body_size: usize,
         _num_trailers: usize,
     ) {
+        log::info!("on_http_call_response (root)");
         // Gather the response body of previously dispatched async HTTP call.
         let body = match self.get_http_call_response_body(0, body_size) {
             Some(body) => body,
@@ -210,6 +211,7 @@ struct HttpHandler {
 
 impl HttpContext for HttpHandler {
     fn on_http_request_headers(&mut self, _num_headers: usize, _end_of_stream: bool) -> Action {
+        log::info!("on_http_request_headers");
         match self.authenticate() {
             Ok(claims) => self.token_claims = Some(claims),
             Err(e) => {
@@ -226,78 +228,85 @@ impl HttpContext for HttpHandler {
         Action::Continue
     }
 
-    fn on_http_request_body(&mut self, _body_size: usize, end_of_stream: bool) -> Action {
-        // pause if we've already dispatched a call
-        if self.get_scopes_dispatched {
-            return Action::Pause;
-        }
-        if let Some(method_name) = self.get_thrift_method_from_body() {
-            self.apply_thrift_auth(method_name);
-            return Action::Pause;
-        }
-
-        if end_of_stream {
-            log::info!("Reached end of stream without method name");
-
-            self.send_http_response(
-                401,
-                vec![("Powered-By", POWERED_BY)],
-                Some(b"Access forbidden.\n"),
-            );
-        };
-
-        Action::Pause
-    }
-
-    // NOTE: I just wanted to send a fake http_response so we could trigger a "response handler"
-    // to come into the lifecycle. Unfortunately, the handler never got triggered. Something in self.send_http_response
-    // isn't working like I'd expect.
-
     // fn on_http_request_body(&mut self, _body_size: usize, end_of_stream: bool) -> Action {
-    //     log::info!("on_http_request_body");
     //     // pause if we've already dispatched a call
     //     if self.get_scopes_dispatched {
     //         return Action::Pause;
     //     }
     //     if let Some(method_name) = self.get_thrift_method_from_body() {
-    //         log::warn!("Thrift method: {:?}", method_name);
-    //         self.send_http_response(
-    //             200,
-    //             vec![("Powered-By", POWERED_BY), (THRIFT_METHOD_HEADER, method_name.as_str())],
-    //             None,
-    //         );
-    //         log::warn!("THRIFT_METHOD_HEADER returned");
-    //         self.get_scopes_dispatched = true;
+    //         self.apply_thrift_auth(method_name);
     //         return Action::Pause;
     //     }
-    //
+    // 
     //     if end_of_stream {
     //         log::info!("Reached end of stream without method name");
-    //
+    // 
     //         self.send_http_response(
     //             401,
     //             vec![("Powered-By", POWERED_BY)],
     //             Some(b"Access forbidden.\n"),
     //         );
     //     };
-    //
+    // 
     //     Action::Pause
     // }
+
+    // NOTE: I just wanted to send a fake http_response so we could trigger a "response handler"
+    // to come into the lifecycle. Unfortunately, the handler never got triggered. Something in self.send_http_response
+    // isn't working like I'd expect.
+
+    fn on_http_request_body(&mut self, _body_size: usize, end_of_stream: bool) -> Action {
+        log::info!("on_http_request_body");
+        // pause if we've already dispatched a call
+        if self.get_scopes_dispatched {
+            return Action::Pause;
+        }
+        if let Some(method_name) = self.get_thrift_method_from_body() {
+            log::info!("Thrift method: {:?}", method_name);
+            self.get_scopes_dispatched = true;
+            match self.handle_get_scopes_locally(method_name) {
+                Ok(_) =>  return Action::Continue,
+                Err(AuthError::Unauthenticated(_)) => {
+                    self.send_http_response(
+                        401,
+                        vec![("Powered-By", POWERED_BY)],
+                        Some(b"Access forbidden.\n"),
+                    );
+                    
+                },
+                Err(AuthError::Unauthorized(_)) => {
+                    self.send_http_response(
+                        403,
+                        vec![("Powered-By", POWERED_BY)],
+                        Some(b"Unauthorized.\n"),
+                    );
+                }
+            }
+            // if self.apply_thrift_auth_locally(method_name).is_ok() {
+            //     return Action::Continue;
+            // } else {
+            //     self.send_http_response(
+            //         401,
+            //         vec![("Powered-By", POWERED_BY)],
+            //         Some(b"Access forbidden.\n"),
+            //     );
+            
+        }
+        if end_of_stream {
+            log::info!("Reached end of stream without method name");
+    
+            self.send_http_response(
+                401,
+                vec![("Powered-By", POWERED_BY)],
+                Some(b"Access forbidden.\n"),
+            );
+        };
+    
+        Action::Pause
+    }
 }
 
 impl Context for HttpHandler {
-    fn on_http_call_response(
-        &mut self,
-        _token_id: u32,
-        _num_headers: usize,
-        body_size: usize,
-        _num_trailers: usize,
-    ) {
-        let body = self.get_http_call_response_body(0, body_size);
-        self.handle_get_scopes_res(body);
-    }
-
-    // // This variant uses a locally parsed Thrift file
     // fn on_http_call_response(
     //     &mut self,
     //     _token_id: u32,
@@ -305,31 +314,43 @@ impl Context for HttpHandler {
     //     body_size: usize,
     //     _num_trailers: usize,
     // ) {
-    //     let _ = self.get_http_call_response_body(0, body_size);
+    //     let body = self.get_http_call_response_body(0, body_size);
+    //     self.handle_get_scopes_res(body);
+    // }
+
+    // This variant uses a locally parsed Thrift file
+    // fn on_http_call_response(
+    //     &mut self,
+    //     _token_id: u32,
+    //     _num_headers: usize,
+    //     body_size: usize,
+    //     _num_trailers: usize,
+    // ) {
+    //     log::info!("on_http_call_response");
     //     let method_name = self
     //         .get_http_call_response_header(THRIFT_METHOD_HEADER)
     //         .map(|header| header)
     //         .expect("Missing thrift method");
-    //
+    // 
     //     self.handle_get_scopes_locally(method_name);
     // }
 }
 
 impl HttpHandler {
-    fn apply_thrift_auth(&mut self, method_name: String) -> () {
-        match self.dispatch_get_scopes(method_name) {
-            Ok(_) => (),
-            Err(e) => {
-                log::warn!("failed to get scopes: {:?}", e);
-
-                self.send_http_response(
-                    401,
-                    vec![("Powered-By", POWERED_BY)],
-                    Some(b"Access forbidden.\n"),
-                );
-            }
-        }
-    }
+    // fn apply_thrift_auth(&mut self, method_name: String) -> () {
+    //     match self.dispatch_get_scopes(method_name) {
+    //         Ok(_) => (),
+    //         Err(e) => {
+    //             log::warn!("failed to get scopes: {:?}", e);
+    // 
+    //             self.send_http_response(
+    //                 401,
+    //                 vec![("Powered-By", POWERED_BY)],
+    //                 Some(b"Access forbidden.\n"),
+    //             );
+    //         }
+    //     }
+    // }
 
     fn apply_thrift_auth_locally(&mut self, method_name: String) -> Result<(), Box<dyn Error>> {
         let service_name = self
@@ -367,86 +388,16 @@ impl HttpHandler {
         Some(method_name)
     }
 
-    fn dispatch_get_scopes(&mut self, method_name: String) -> Result<(), Box<dyn Error>> {
-        let service_name = self
-            .config
-            .service_name
-            .as_ref()
-            .ok_or("Service name not found")?;
-
-        let annotations = self
-            .thrift_config
-            .get(service_name)
-            .map(|service_thrift| service_thrift.methods.get(method_name.as_str()))
-            .map(|method| method.unwrap().annotations.clone())
-            .ok_or("Annotations not found")?;
-
-        let required_scopes = annotations.get("scope");
-
-        log::info!("Scopes from Rust-parsed Scopes: {:?}", required_scopes);
-
-        self.dispatch_http_call(
-            "auth",
-            vec![
-                (":method", "GET"),
-                (":path", &format!("/scopes/{service_name}/{method_name}")),
-                (":authority", "auth"),
-            ],
-            None,
-            vec![],
-            Duration::from_secs(1),
-        )
-        .map_err(|status| format!("Failed to dispatch get scopes call: status {:?}", status))?;
-
-        self.get_scopes_dispatched = true;
-
-        Ok(())
-    }
-
-    fn handle_get_scopes_res(&self, body: Option<Vec<u8>>) {
-        match self.validate_auth(body) {
-            Ok(_) => self.resume_http_request(),
-            Err(AuthError::Unauthenticated(message)) => {
-                log::warn!("Unauthenticated: {:?}", message);
-
-                self.send_http_response(
-                    401,
-                    vec![("Powered-By", POWERED_BY)],
-                    Some(b"Access forbidden.\n"),
-                );
-            }
-            Err(AuthError::Unauthorized(message)) => {
-                log::warn!("Unauthorized: {:?}", message);
-
-                self.send_http_response(
-                    403,
-                    vec![("Powered-By", POWERED_BY)],
-                    Some(b"Access forbidden.\n"),
-                );
-            }
-        }
-    }
-
-    fn handle_get_scopes_locally(&self, method_name: String) {
+    fn handle_get_scopes_locally(&self, method_name: String) -> Result<Action, AuthError> {
         match self.validate_auth_with_local_thrift(method_name) {
-            Ok(_) => self.resume_http_request(),
+            Ok(_) => Ok(Action::Continue),
             Err(AuthError::Unauthenticated(message)) => {
                 log::warn!("Unauthenticated: {:?}", message);
-
-                self.send_http_response(
-                    401,
-                    vec![("Powered-By", POWERED_BY)],
-                    Some(b"Access forbidden.\n"),
-                );
+                Err(AuthError::Unauthenticated(message))
             }
             Err(AuthError::Unauthorized(message)) => {
                 log::warn!("Unauthorized: {:?}", message);
-
-                self.send_http_response(
-                    403,
-                    vec![("Powered-By", POWERED_BY)],
-                    Some(b"Access forbidden.\n"),
-                );
+                Err(AuthError::Unauthorized(message))
             }
         }
     }
@@ -502,7 +453,10 @@ impl HttpHandler {
             required_scopes.iter().map(|s| s.to_string()).collect(),
             &claims.custom.scopes,
         )
-        .map_err(|e| AuthError::Unauthorized(e.to_string()))?;
+            .map_err(|e| {
+                log::error!("{}", e.to_string());
+                AuthError::Unauthorized(e.to_string())
+            }).expect("TODO: panic message");
 
         Ok(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,8 +22,6 @@ const PUBLIC_KEY_REFRESH_INTERVAL: Duration = Duration::from_secs(3);
 const PUBLIC_KEY_CACHE_KEY: &str = "public_key";
 const POWERED_BY: &str = "wasm-envoy-proxy";
 
-const THRIFT_METHOD_HEADER: &str = "X-Thrift-Method";
-
 #[derive(Deserialize, Debug, Default, Clone)]
 #[serde(default)]
 struct FilterConfig {
@@ -51,11 +49,6 @@ struct Jwk {
 #[derive(Default, Clone)]
 struct RootHandler {
     config: FilterConfig,
-}
-
-#[derive(Deserialize)]
-struct GetScopesResponse {
-    scopes: String,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -253,26 +246,6 @@ impl HttpContext for HttpHandler {
 impl Context for HttpHandler {}
 
 impl HttpHandler {
-
-    fn apply_thrift_auth_locally(&mut self, method_name: String) -> Result<(), Box<dyn Error>> {
-        let service_name = self
-            .config
-            .service_name
-            .as_ref()
-            .ok_or("Service name not found")?;
-
-        let annotations = self
-            .thrift_config
-            .get(service_name)
-            .map(|service_thrift| service_thrift.methods.get(method_name.as_str()))
-            .map(|method| method.unwrap().annotations.clone())
-            .ok_or("Annotations not found")?;
-
-        let required_scopes = annotations.get("scope");
-
-        log::info!("Scopes from Rust-parsed Scopes: {:?}", required_scopes);
-        Ok(())
-    }
 
     fn get_thrift_method_from_body(&self) -> Option<String> {
         let method_length = match self.get_http_request_body(4, 4) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
 mod parse;
 
-use std::collections::HashMap;
 use jwt_simple::{
     claims::JWTClaims,
     prelude::{RS256PublicKey, RSAPublicKeyLike},
@@ -8,15 +7,16 @@ use jwt_simple::{
 use log;
 use serde::{Deserialize, Serialize};
 use serde_json::from_slice;
+use std::collections::HashMap;
 use std::error::Error;
 use std::time::Duration;
 
+use crate::parse::Service;
 use base64::prelude::*;
 use proxy_wasm::{
     traits::{Context, HttpContext, RootContext},
     types::{Action, ContextType, LogLevel},
 };
-use crate::parse::Service;
 
 const PUBLIC_KEY_REFRESH_INTERVAL: Duration = Duration::from_secs(3);
 const PUBLIC_KEY_CACHE_KEY: &str = "public_key";
@@ -86,8 +86,8 @@ impl RootContext for RootHandler {
             config: self.config.clone(),
             token_claims: None,
             get_scopes_dispatched: false,
-            scopes_file: include_str!("../hack/PotatoService.thrift").to_string(),
-            thrift_config: parse::parse_thrift(include_str!("../hack/PotatoService.thrift")).expect("failed to parse thrift file"),
+            thrift_config: parse::parse_thrift(include_str!("../hack/PotatoService.thrift"))
+                .expect("failed to parse thrift file"),
         }))
     }
 
@@ -146,7 +146,6 @@ impl RootContext for RootHandler {
     }
 }
 
-
 impl Context for RootHandler {
     fn on_http_call_response(
         &mut self,
@@ -155,14 +154,9 @@ impl Context for RootHandler {
         body_size: usize,
         _num_trailers: usize,
     ) {
-        log::warn!("RAWR");
         // Gather the response body of previously dispatched async HTTP call.
         let body = match self.get_http_call_response_body(0, body_size) {
-            Some(body) => {
-
-                log::warn!("RAWR body: {:?}", String::from_utf8_lossy(&body));
-                body
-            },
+            Some(body) => body,
             None => {
                 log::warn!("header providing service returned empty body");
 
@@ -182,7 +176,6 @@ impl RootHandler {
                 log::error!("Failed to parse JWKS: {:?}", e);
                 return;
             }
-            
         };
 
         let pubkey_comps = match jwks.keys.iter().find(|key| key.alg == "RS256") {
@@ -212,13 +205,11 @@ struct HttpHandler {
     config: FilterConfig,
     token_claims: Option<JWTClaims<CustomClaims>>,
     get_scopes_dispatched: bool,
-    scopes_file: String,
-    thrift_config: HashMap<String, Service> 
+    thrift_config: HashMap<String, Service>,
 }
 
 impl HttpContext for HttpHandler {
     fn on_http_request_headers(&mut self, _num_headers: usize, _end_of_stream: bool) -> Action {
-        log::info!("on_http_request_headers");
         match self.authenticate() {
             Ok(claims) => self.token_claims = Some(claims),
             Err(e) => {
@@ -244,20 +235,24 @@ impl HttpContext for HttpHandler {
             self.apply_thrift_auth(method_name);
             return Action::Pause;
         }
-        
+
         if end_of_stream {
             log::info!("Reached end of stream without method name");
-    
+
             self.send_http_response(
                 401,
                 vec![("Powered-By", POWERED_BY)],
                 Some(b"Access forbidden.\n"),
             );
         };
-    
+
         Action::Pause
     }
-    
+
+    // NOTE: I just wanted to send a fake http_response so we could trigger a "response handler"
+    // to come into the lifecycle. Unfortunately, the handler never got triggered. Something in self.send_http_response
+    // isn't working like I'd expect.
+
     // fn on_http_request_body(&mut self, _body_size: usize, end_of_stream: bool) -> Action {
     //     log::info!("on_http_request_body");
     //     // pause if we've already dispatched a call
@@ -275,17 +270,17 @@ impl HttpContext for HttpHandler {
     //         self.get_scopes_dispatched = true;
     //         return Action::Pause;
     //     }
-    // 
+    //
     //     if end_of_stream {
     //         log::info!("Reached end of stream without method name");
-    // 
+    //
     //         self.send_http_response(
     //             401,
     //             vec![("Powered-By", POWERED_BY)],
     //             Some(b"Access forbidden.\n"),
     //         );
     //     };
-    // 
+    //
     //     Action::Pause
     // }
 }
@@ -301,7 +296,7 @@ impl Context for HttpHandler {
         let body = self.get_http_call_response_body(0, body_size);
         self.handle_get_scopes_res(body);
     }
-    
+
     // // This variant uses a locally parsed Thrift file
     // fn on_http_call_response(
     //     &mut self,
@@ -315,13 +310,13 @@ impl Context for HttpHandler {
     //         .get_http_call_response_header(THRIFT_METHOD_HEADER)
     //         .map(|header| header)
     //         .expect("Missing thrift method");
-    //     
+    //
     //     self.handle_get_scopes_locally(method_name);
     // }
 }
 
 impl HttpHandler {
-    fn apply_thrift_auth(&mut self, method_name: String) -> () { 
+    fn apply_thrift_auth(&mut self, method_name: String) -> () {
         match self.dispatch_get_scopes(method_name) {
             Ok(_) => (),
             Err(e) => {
@@ -335,7 +330,7 @@ impl HttpHandler {
             }
         }
     }
-    
+
     fn apply_thrift_auth_locally(&mut self, method_name: String) -> Result<(), Box<dyn Error>> {
         let service_name = self
             .config
@@ -343,25 +338,30 @@ impl HttpHandler {
             .as_ref()
             .ok_or("Service name not found")?;
 
-        let required_scopes = self.thrift_config
+        let annotations = self
+            .thrift_config
             .get(service_name)
             .map(|service_thrift| service_thrift.methods.get(method_name.as_str()))
             .map(|method| method.unwrap().annotations.clone())
-            .ok_or("Scopes not found")?;
+            .ok_or("Annotations not found")?;
 
-        println!("Scopes from Rust-parsed Thrift file: {:?}", required_scopes);
+        let required_scopes = annotations.get("scope");
+
+        log::info!("Scopes from Rust-parsed Scopes: {:?}", required_scopes);
         Ok(())
     }
 
     fn get_thrift_method_from_body(&self) -> Option<String> {
         let method_length = match self.get_http_request_body(4, 4) {
-            Some(bytes) if bytes.len() == 4 => usize::from_be_bytes(bytes.try_into().expect("Expected 4 bytes")),
-            _ => return None
+            Some(bytes) if bytes.len() == 4 => {
+                usize::from_be_bytes(bytes.try_into().expect("Expected 4 bytes"))
+            }
+            _ => return None,
         };
 
         let method_name = match self.get_http_request_body(8, method_length) {
-            Some(bytes) if bytes.len() == method_length  => String::from_utf8(bytes).unwrap(),
-            _ => return None
+            Some(bytes) if bytes.len() == method_length => String::from_utf8(bytes).unwrap(),
+            _ => return None,
         };
 
         Some(method_name)
@@ -373,6 +373,17 @@ impl HttpHandler {
             .service_name
             .as_ref()
             .ok_or("Service name not found")?;
+
+        let annotations = self
+            .thrift_config
+            .get(service_name)
+            .map(|service_thrift| service_thrift.methods.get(method_name.as_str()))
+            .map(|method| method.unwrap().annotations.clone())
+            .ok_or("Annotations not found")?;
+
+        let required_scopes = annotations.get("scope");
+
+        log::info!("Scopes from Rust-parsed Scopes: {:?}", required_scopes);
 
         self.dispatch_http_call(
             "auth",
@@ -386,7 +397,6 @@ impl HttpHandler {
             Duration::from_secs(1),
         )
         .map_err(|status| format!("Failed to dispatch get scopes call: status {:?}", status))?;
-
 
         self.get_scopes_dispatched = true;
 
@@ -417,35 +427,36 @@ impl HttpHandler {
         }
     }
 
+    fn handle_get_scopes_locally(&self, method_name: String) {
+        match self.validate_auth_with_local_thrift(method_name) {
+            Ok(_) => self.resume_http_request(),
+            Err(AuthError::Unauthenticated(message)) => {
+                log::warn!("Unauthenticated: {:?}", message);
 
-    // fn handle_get_scopes_locally(&self, method_name: String) {
-    //     match self.validate_auth_with_local_thrift(method_name) {
-    //         Ok(_) => self.resume_http_request(),
-    //         Err(AuthError::Unauthenticated(message)) => {
-    //             log::warn!("Unauthenticated: {:?}", message);
-    // 
-    //             self.send_http_response(
-    //                 401,
-    //                 vec![("Powered-By", POWERED_BY)],
-    //                 Some(b"Access forbidden.\n"),
-    //             );
-    //         }
-    //         Err(AuthError::Unauthorized(message)) => {
-    //             log::warn!("Unauthorized: {:?}", message);
-    // 
-    //             self.send_http_response(
-    //                 403,
-    //                 vec![("Powered-By", POWERED_BY)],
-    //                 Some(b"Access forbidden.\n"),
-    //             );
-    //         }
-    //     }
-    // }
+                self.send_http_response(
+                    401,
+                    vec![("Powered-By", POWERED_BY)],
+                    Some(b"Access forbidden.\n"),
+                );
+            }
+            Err(AuthError::Unauthorized(message)) => {
+                log::warn!("Unauthorized: {:?}", message);
+
+                self.send_http_response(
+                    403,
+                    vec![("Powered-By", POWERED_BY)],
+                    Some(b"Access forbidden.\n"),
+                );
+            }
+        }
+    }
     fn validate_auth(&self, body: Option<Vec<u8>>) -> Result<(), AuthError> {
         let claims = self
             .token_claims
             .as_ref()
-            .ok_or(AuthError::Unauthenticated("Missing token claims".to_string()))?;
+            .ok_or(AuthError::Unauthenticated(
+                "Missing token claims".to_string(),
+            ))?;
 
         let parsed_scope_response = self
             .parse_required_scopes(body)
@@ -462,12 +473,14 @@ impl HttpHandler {
 
         Ok(())
     }
-    
+
     fn validate_auth_with_local_thrift(&self, method_name: String) -> Result<(), AuthError> {
         let claims = self
             .token_claims
             .as_ref()
-            .ok_or(AuthError::Unauthenticated("Missing token claims".to_string()))?;
+            .ok_or(AuthError::Unauthenticated(
+                "Missing token claims".to_string(),
+            ))?;
 
         let service_name = self
             .config
@@ -475,16 +488,21 @@ impl HttpHandler {
             .as_ref()
             .expect("Service name not found");
 
-        let required_scopes = self.thrift_config
+        let required_scopes = self
+            .thrift_config
             .get(service_name)
             .map(|service_thrift| service_thrift.methods.get(method_name.as_str()))
             .map(|method| method.unwrap().annotations.clone())
-            .ok_or("Scopes not found").expect("scopes not found by service_name and method");
-        
+            .ok_or("Scopes not found")
+            .expect("scopes not found by service_name and method");
+
         let required_scopes = vec![required_scopes.get("scope").expect("missing scopes")];
-        
-        self.authorize(required_scopes.iter().map(|s| s.to_string()).collect(), &claims.custom.scopes)
-            .map_err(|e| AuthError::Unauthorized(e.to_string()))?;
+
+        self.authorize(
+            required_scopes.iter().map(|s| s.to_string()).collect(),
+            &claims.custom.scopes,
+        )
+        .map_err(|e| AuthError::Unauthorized(e.to_string()))?;
 
         Ok(())
     }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -22,14 +22,15 @@ static METHOD_RE: Lazy<Regex> = Lazy::new(|| {
 });
 
 #[derive(Debug)]
-pub struct Method {
+pub struct MethodConfiguration {
     return_type: String,
     pub annotations: HashMap<String, String>,
 }
 
+type MethodName = String;
 #[derive(Debug)]
 pub struct Service {
-    pub methods: HashMap<String, Method>,
+    pub methods: HashMap<MethodName, MethodConfiguration>,
 }
 
 // Function to parse annotations from strings like `scope="read" role="chef"`
@@ -80,7 +81,7 @@ pub fn parse_thrift(file_contents: &str) -> Result<HashMap<String, Service>, Str
 
             methods.insert(
                 method_name.clone(),
-                Method {
+                MethodConfiguration {
                     return_type,
                     annotations,
                 },

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1,0 +1,207 @@
+use regex::Regex;
+use std::collections::HashMap;
+
+use once_cell::sync::Lazy;
+
+static ANNOTATION_RE: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r#"(?P<key>\w+)\s*=\s*"(?P<value>[^"]*)""#).unwrap()
+});
+
+static NAMESPACE_RE: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"namespace\s+\w+\s+(?P<namespace>[\w.]+)").unwrap()
+});
+
+//service
+static SERVICE_RE: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"service\s+(?P<service_name>\w+)\s*\{(?P<service_body>[^}]*)\}").unwrap()
+});
+
+// method
+static METHOD_RE: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"(?P<return_type>\w+)\s+(?P<method_name>\w+)\s*\([^)]*\)\s*(?:\(\s*(?P<annotations>[^)]*)\s*\))?").unwrap()
+});
+
+#[derive(Debug)]
+pub struct Method {
+    return_type: String,
+    pub annotations: HashMap<String, String>,
+}
+
+#[derive(Debug)]
+pub struct Service {
+    pub methods: HashMap<String, Method>,
+}
+
+// Function to parse annotations from strings like `scope="read" role="chef"`
+fn parse_annotations(annotation_str: &str) -> HashMap<String, String> {
+    let mut annotations = HashMap::new();
+    for cap in ANNOTATION_RE.captures_iter(annotation_str) {
+        if let (Some(key), Some(value)) = (cap.name("key"), cap.name("value")) {
+            annotations.insert(key.as_str().to_string(), value.as_str().to_string());
+        }
+    }
+    annotations
+}
+
+// Parse the Thrift file contents, extracting services, methods, and annotations
+pub fn parse_thrift(file_contents: &str) -> Result<HashMap<String, Service>, String> {
+    let content = file_contents;
+
+    // Remove comments starting with "//"
+    let comment_re = Regex::new(r"//.*$").or_else(|e| Err("error building regex") );
+    let content = comment_re?.replace_all(&content, "");
+
+    // Extract namespace
+    let namespace = NAMESPACE_RE 
+        .captures(&content)
+        .and_then(|cap| cap.name("namespace").map(|m| m.as_str().to_string()));
+
+    // If namespace is not found, return an error
+    let namespace = namespace.ok_or_else(|| "Namespace not found".to_string())?;
+
+    // Extract services and methods
+
+    let mut services = HashMap::new();
+
+    // Iterate over services in the file
+    for service_cap in SERVICE_RE.captures_iter(&content) {
+        let service_name = &service_cap.name("service_name").ok_or("Service name not found")?.as_str();
+        let service_body = &service_cap.name("service_body").ok_or("Service body not found")?.as_str();
+        let mut methods = HashMap::new();
+
+        // Iterate over methods for each service
+        for method_cap in METHOD_RE.captures_iter(service_body) {
+            let return_type =  method_cap.name("return_type").ok_or("Return type not found")?.as_str().to_string();
+            let method_name =  method_cap.name("method_name").ok_or("Method name not found")?.as_str().to_string();
+            let annotations = match method_cap.name("annotations").map(|m| m.as_str()) {
+                Some(annotations) => parse_annotations(annotations),
+                None => HashMap::with_capacity(0),
+            };
+
+            methods.insert(
+                method_name.clone(),
+                Method {
+                    return_type,
+                    annotations,
+                },
+            );
+        }
+
+        // Insert the service into the final collection
+        services.insert(
+            format!("{}.{}", namespace, service_name),
+            Service { methods },
+        );
+    }
+
+    Ok(services)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_annotations_basic() {
+        let input = r#"scope="read" role="chef""#;
+        let annotations = parse_annotations(input);
+        assert_eq!(annotations.get("scope"), Some(&"read".to_string()));
+        assert_eq!(annotations.get("role"), Some(&"chef".to_string()));
+    }
+
+    #[test]
+    fn test_parse_thrift_potato_service() {
+        let thrift_content = r#"
+        namespace go my.potato
+
+        service PotatoService {
+            string getPotato(1:string id) (scope="read")
+            void mashPotato(1:string id, 2:i32 level) (scope="write" role="chef")
+        }
+    "#;
+
+        let services = parse_thrift(thrift_content).expect("Failed to parse Thrift content");
+        println!("services: {:?}", services.keys().collect::<Vec<_>>());
+        let service = services.get("my.potato.PotatoService").expect("Service not found");
+
+        let get_potato = service.methods.get("getPotato").expect("Method getPotato not found");
+        assert_eq!(get_potato.return_type, "string");
+        assert_eq!(get_potato.annotations.get("scope"), Some(&"read".to_string()));
+
+        let mash_potato = service.methods.get("mashPotato").expect("Method mashPotato not found");
+        assert_eq!(mash_potato.return_type, "void");
+        assert_eq!(mash_potato.annotations.get("scope"), Some(&"write".to_string()));
+        assert_eq!(mash_potato.annotations.get("role"), Some(&"chef".to_string()));
+    }
+
+    #[test]
+    fn test_parse_thrift_multiline_annotations() {
+        let thrift_content = r#"
+            namespace go my.potato
+            service PotatoService {
+                void bakePotato(
+                    1:string type,
+                    2:i32 temp
+                ) (
+                    scope = "oven",
+                    role = "baker"
+                )
+            }
+        "#;
+
+        let services = parse_thrift(thrift_content).unwrap();
+        let service = services.get("my.potato.PotatoService").unwrap();
+        let method = service.methods.get("bakePotato").unwrap();
+
+        assert_eq!(method.return_type, "void");
+        assert_eq!(method.annotations.get("scope"), Some(&"oven".to_string()));
+        assert_eq!(method.annotations.get("role"), Some(&"baker".to_string()));
+    }
+
+    #[test]
+    fn test_parse_thrift_invalid_annotation_format() {
+        let thrift_content = r#"
+            namespace go my.potato
+            service PotatoService {
+                void explodePotato(1:string reason) (this_is_invalid)
+            }
+        "#;
+    
+        let services = parse_thrift(thrift_content).unwrap();
+        let service = services.get("my.potato.PotatoService").unwrap();
+        let method = service.methods.get("explodePotato").unwrap();
+    
+        assert_eq!(method.return_type, "void");
+        assert!(method.annotations.is_empty());
+    }
+
+    #[test]
+    fn test_parse_thrift_no_annotations() {
+        let thrift_content = r#"
+            namespace go my.potato
+            service PotatoService {
+                i32 boilPotato(1:i32 duration)
+            }
+        "#;
+    
+        let services = parse_thrift(thrift_content).unwrap();
+        let service = services.get("my.potato.PotatoService").unwrap();
+        let method = service.methods.get("boilPotato").unwrap();
+    
+        assert_eq!(method.return_type, "i32");
+        assert!(method.annotations.is_empty());
+    }
+
+    #[test]
+    fn test_parse_thrift_missing_namespace() {
+        let thrift_content = r#"
+            service PotatoService {
+                bool isHot() (temperature="high")
+            }
+        "#;
+    
+        let result = parse_thrift(thrift_content);
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err(), "Namespace not found");
+    }
+}

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -3,13 +3,11 @@ use std::collections::HashMap;
 
 use once_cell::sync::Lazy;
 
-static ANNOTATION_RE: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r#"(?P<key>\w+)\s*=\s*"(?P<value>[^"]*)""#).unwrap()
-});
+static ANNOTATION_RE: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r#"(?P<key>\w+)\s*=\s*"(?P<value>[^"]*)""#).unwrap());
 
-static NAMESPACE_RE: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r"namespace\s+\w+\s+(?P<namespace>[\w.]+)").unwrap()
-});
+static NAMESPACE_RE: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"namespace\s+\w+\s+(?P<namespace>[\w.]+)").unwrap());
 
 //service
 static SERVICE_RE: Lazy<Regex> = Lazy::new(|| {
@@ -49,11 +47,11 @@ pub fn parse_thrift(file_contents: &str) -> Result<HashMap<String, Service>, Str
     let content = file_contents;
 
     // Remove comments starting with "//"
-    let comment_re = Regex::new(r"//.*$").or_else(|e| Err("error building regex") );
+    let comment_re = Regex::new(r"//.*$").or_else(|e| Err("error building regex"));
     let content = comment_re?.replace_all(&content, "");
 
     // Extract namespace
-    let namespace = NAMESPACE_RE 
+    let namespace = NAMESPACE_RE
         .captures(&content)
         .and_then(|cap| cap.name("namespace").map(|m| m.as_str().to_string()));
 
@@ -66,14 +64,28 @@ pub fn parse_thrift(file_contents: &str) -> Result<HashMap<String, Service>, Str
 
     // Iterate over services in the file
     for service_cap in SERVICE_RE.captures_iter(&content) {
-        let service_name = &service_cap.name("service_name").ok_or("Service name not found")?.as_str();
-        let service_body = &service_cap.name("service_body").ok_or("Service body not found")?.as_str();
+        let service_name = &service_cap
+            .name("service_name")
+            .ok_or("Service name not found")?
+            .as_str();
+        let service_body = &service_cap
+            .name("service_body")
+            .ok_or("Service body not found")?
+            .as_str();
         let mut methods = HashMap::new();
 
         // Iterate over methods for each service
         for method_cap in METHOD_RE.captures_iter(service_body) {
-            let return_type =  method_cap.name("return_type").ok_or("Return type not found")?.as_str().to_string();
-            let method_name =  method_cap.name("method_name").ok_or("Method name not found")?.as_str().to_string();
+            let return_type = method_cap
+                .name("return_type")
+                .ok_or("Return type not found")?
+                .as_str()
+                .to_string();
+            let method_name = method_cap
+                .name("method_name")
+                .ok_or("Method name not found")?
+                .as_str()
+                .to_string();
             let annotations = match method_cap.name("annotations").map(|m| m.as_str()) {
                 Some(annotations) => parse_annotations(annotations),
                 None => HashMap::with_capacity(0),
@@ -123,16 +135,33 @@ mod tests {
 
         let services = parse_thrift(thrift_content).expect("Failed to parse Thrift content");
         println!("services: {:?}", services.keys().collect::<Vec<_>>());
-        let service = services.get("my.potato.PotatoService").expect("Service not found");
+        let service = services
+            .get("my.potato.PotatoService")
+            .expect("Service not found");
 
-        let get_potato = service.methods.get("getPotato").expect("Method getPotato not found");
+        let get_potato = service
+            .methods
+            .get("getPotato")
+            .expect("Method getPotato not found");
         assert_eq!(get_potato.return_type, "string");
-        assert_eq!(get_potato.annotations.get("scope"), Some(&"read".to_string()));
+        assert_eq!(
+            get_potato.annotations.get("scope"),
+            Some(&"read".to_string())
+        );
 
-        let mash_potato = service.methods.get("mashPotato").expect("Method mashPotato not found");
+        let mash_potato = service
+            .methods
+            .get("mashPotato")
+            .expect("Method mashPotato not found");
         assert_eq!(mash_potato.return_type, "void");
-        assert_eq!(mash_potato.annotations.get("scope"), Some(&"write".to_string()));
-        assert_eq!(mash_potato.annotations.get("role"), Some(&"chef".to_string()));
+        assert_eq!(
+            mash_potato.annotations.get("scope"),
+            Some(&"write".to_string())
+        );
+        assert_eq!(
+            mash_potato.annotations.get("role"),
+            Some(&"chef".to_string())
+        );
     }
 
     #[test]
@@ -167,11 +196,11 @@ mod tests {
                 void explodePotato(1:string reason) (this_is_invalid)
             }
         "#;
-    
+
         let services = parse_thrift(thrift_content).unwrap();
         let service = services.get("my.potato.PotatoService").unwrap();
         let method = service.methods.get("explodePotato").unwrap();
-    
+
         assert_eq!(method.return_type, "void");
         assert!(method.annotations.is_empty());
     }
@@ -184,11 +213,11 @@ mod tests {
                 i32 boilPotato(1:i32 duration)
             }
         "#;
-    
+
         let services = parse_thrift(thrift_content).unwrap();
         let service = services.get("my.potato.PotatoService").unwrap();
         let method = service.methods.get("boilPotato").unwrap();
-    
+
         assert_eq!(method.return_type, "i32");
         assert!(method.annotations.is_empty());
     }
@@ -200,7 +229,7 @@ mod tests {
                 bool isHot() (temperature="high")
             }
         "#;
-    
+
         let result = parse_thrift(thrift_content);
         assert!(result.is_err());
         assert_eq!(result.unwrap_err(), "Namespace not found");


### PR DESCRIPTION
- Includes the Thrift configuration in the plugin binary and parses it on startup
- Evaluation of rule matching is now done via that configuration.
![Log](https://github.com/user-attachments/assets/565d8e5c-c0a5-40d8-85fc-6c8f7b18695b)
- No external calls to an auth service needed!


